### PR TITLE
Fixed #38

### DIFF
--- a/slicer_plugin/SlicerNNInteractive/SlicerNNInteractive.py
+++ b/slicer_plugin/SlicerNNInteractive/SlicerNNInteractive.py
@@ -27,7 +27,7 @@ from PythonQt.QtGui import QMessageBox
 ###############################################################################
 
 
-DEBUG_MODE = False
+DEBUG_MODE = True
 
 
 def debug_print(*args):
@@ -995,7 +995,11 @@ class SlicerNNInteractiveWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
         # Mark the segmentation as modified so the UI updates
         segmentationNode.Modified()
 
-        segmentationNode.GetSegmentation().CollapseBinaryLabelmaps()
+        if segmentation_mask.sum() > 0:
+            # If we do this when segmentation_mask.sum() == 0, sometimes Slicer will throw "bogus" OOM errors
+            # (see https://github.com/coendevente/SlicerNNInteractive/issues/38)
+            segmentationNode.GetSegmentation().CollapseBinaryLabelmaps()
+        
         del segmentation_mask
 
         debug_print(f"show_segmentation took {time.time() - t0}")

--- a/slicer_plugin/SlicerNNInteractive/SlicerNNInteractive.py
+++ b/slicer_plugin/SlicerNNInteractive/SlicerNNInteractive.py
@@ -27,7 +27,7 @@ from PythonQt.QtGui import QMessageBox
 ###############################################################################
 
 
-DEBUG_MODE = True
+DEBUG_MODE = False
 
 
 def debug_print(*args):


### PR DESCRIPTION
I noticed that when the segmentation mask that is set using `slicer.util.updateSegmentBinaryLabelmapFromArray` is empty, in some cases (it doesn't seem to happen when `SlicerNNInteractiveWidget.show_segmentation` is called from `SlicerNNInteractiveWidget.clear_current_segment`), the line in `SlicerNNInteractiveWidget.show_segmentation`:

```
segmentationNode.GetSegmentation().CollapseBinaryLabelmaps()
```

causes the OOM error as described in #38.

I added a check to only do `CollapseBinaryLabelmaps` when `segmentation_mask.sum() > 0`.

This seems to have fixed it.