### PR TITLE
Mark segment as edited

### DIFF
--- a/slicer_plugin/SlicerNNInteractive/SlicerNNInteractive.py
+++ b/slicer_plugin/SlicerNNInteractive/SlicerNNInteractive.py
@@ -990,6 +990,11 @@ class SlicerNNInteractiveWidget(ScriptedLoadableModuleWidget, VTKObservationMixi
             if was_3d_shown:
                 segmentationNode.CreateClosedSurfaceRepresentation()
 
+        # Mark the segment as being edited (can be useful for selective saving of only modified segments)
+        segment = segmentationNode.GetSegmentation().GetSegment(selectedSegmentID)
+        if slicer.vtkSlicerSegmentationsModuleLogic.GetSegmentStatus(segment) == slicer.vtkSlicerSegmentationsModuleLogic.NotStarted:
+            slicer.vtkSlicerSegmentationsModuleLogic.SetSegmentStatus(segment, slicer.vtkSlicerSegmentationsModuleLogic.InProgress)
+
         # Mark the segmentation as modified so the UI updates
         segmentationNode.Modified()
 


### PR DESCRIPTION
Segment status of edited segments are set to "in progress", which helps with remembering which segments have been modified. This is information may also be used for selective saving of segments (e.g., in TotalSegmentator mode of CaseIterator module).