### PR TITLE
Update server install instructions for Linux 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This will make the server available under port `1527` on your machine. If you wo
 ##### Option 2: Using `pip`
 
 ```
+python3 -m venv path_to_your_virtual_environment
 pip install nninteractive-slicer-server
 nninteractive-slicer-server --host 0.0.0.0 --port 1527
 ```

--- a/README.md
+++ b/README.md
@@ -53,13 +53,23 @@ This will make the server available under port `1527` on your machine. If you wo
 
 ##### Option 2: Using `pip`
 
+If setting for the first time you need to create a python virtual environment by specifying a location on your disk, and then activate that environment. On linux, you can accomplish that by these commands:
+
 ```
-python3 -m venv path_to_your_virtual_environment
+python3 -m venv path_to_your_virtual_environment 
+source path_to_your_virtual_environment/bin/activate
+```
+
+After which you can install the NNinteractive to this environment with these commands:
+
+```
 pip install nninteractive-slicer-server
 nninteractive-slicer-server --host 0.0.0.0 --port 1527
 ```
 
 If you would like to use a different port, say `1627`, replace `--port 1527` with `--port 1627`.
+
+Remember you next time you need to start NNInteractive server, first activate your virtual python environment with the source command above and then just run the `nninteractive-slicer-server --host 0.0.0.0 --port 1527` to start the server. 
 
 > [!NOTE]  
 > When starting the server, you can ignore the message `nnUNet_raw is not defined [...] how to set this up.`. Setting up these environment variables is not necessary when using `SlicerNNInteractive`.


### PR DESCRIPTION
I would like to promote NNInteractive for our SlicerMorph and Morphocloud users. But most of these people are not computationally proficient and not necessarily know that having a python virtual environment is almost always necessary, or how to set one up. 

Without the virtual environment, the provided pip install instructions fails at MorphoCloud instances and people cannot use it. 

I updated the pip install Linux instructions with on how to setup a virtual environment and activate it. 

