### PR TITLE
Add Dockerfile for ARM64/DGX Spark support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ docker pull coendevente/nninteractive-slicer-server:latest
 docker run --gpus all --rm -it -p 1527:1527 coendevente/nninteractive-slicer-server:latest
 ```
 
+###### ARM64 (e.g., NVIDIA DGX Spark)
+
+For ARM64 systems like NVIDIA DGX Spark, build the image locally:
+
+```bash
+git clone https://github.com/coendevente/SlicerNNInteractive.git
+cd SlicerNNInteractive/server
+docker build -f Dockerfile.arm64 -t nninteractive-slicer-server:arm64 .
+docker run --gpus all --rm -it -p 1527:1527 --ipc=host nninteractive-slicer-server:arm64
+```
+
 This will make the server available under port `1527` on your machine. If you would like to use a different port, say `1627`, replace `-p 1527:1527` with `-p 1627:1527`.
 
 ##### Option 2: Using `uv`

--- a/server/Dockerfile.arm64
+++ b/server/Dockerfile.arm64
@@ -1,0 +1,42 @@
+# Dockerfile for ARM64 systems (e.g., NVIDIA DGX Spark with Grace CPU)
+# Uses NVIDIA NGC PyTorch container for proper CUDA support on ARM64
+FROM nvcr.io/nvidia/pytorch:25.01-py3
+
+# Disable GPU compatibility check (GB10 shows warning but works)
+ENV NVIDIA_DISABLE_REQUIRE=1
+
+RUN apt-get update && apt-get install -y wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m user 
+RUN chown -R user:user /home/user
+RUN mkdir -p /home/user/.config/matplotlib && \
+    mkdir -p /home/user/.cache && \
+    chown -R user:user /home/user/.config /home/user/.cache
+
+# Backup NGC PyTorch (compiled for ARM64 with CUDA) before pip overwrites it
+RUN cp -r /usr/local/lib/python3.12/dist-packages/torch /tmp/torch_backup && \
+    cp -r /usr/local/lib/python3.12/dist-packages/torchvision /tmp/torchvision_backup
+
+WORKDIR /opt/server
+
+COPY nninteractive_slicer_server/main.py main.py
+COPY requirements.txt requirements.txt
+
+# Pin numpy<2 for compatibility with NGC PyTorch (compiled against NumPy 1.x)
+RUN sed "s/numpy>=.*/numpy>=1.26.0,<2.0.0/" requirements.txt > requirements_fixed.txt
+
+# Install dependencies (this will install CPU-only torch, which we will replace)
+RUN pip install --no-cache-dir -r requirements_fixed.txt
+
+# Restore NGC PyTorch with ARM64 CUDA support
+RUN rm -rf /usr/local/lib/python3.12/dist-packages/torch && \
+    rm -rf /usr/local/lib/python3.12/dist-packages/torchvision && \
+    mv /tmp/torch_backup /usr/local/lib/python3.12/dist-packages/torch && \
+    mv /tmp/torchvision_backup /usr/local/lib/python3.12/dist-packages/torchvision
+
+RUN chown -R user:user /opt/server
+
+USER user
+
+CMD ["python3", "main.py"]


### PR DESCRIPTION
## Summary

This PR adds ARM64 support for running the nnInteractive server on NVIDIA DGX Spark systems (and other ARM64 platforms with NVIDIA GPUs).

### Key changes:
- Added `Dockerfile.arm64` using NVIDIA NGC PyTorch 25.01 container as base
- Uses NGC PyTorch which is properly compiled for ARM64 with CUDA support
- Preserves NGC PyTorch during dependency installation (pip would otherwise install CPU-only version)
- Pins numpy<2 for compatibility with NGC PyTorch (compiled against NumPy 1.x)

### Tested on:
- NVIDIA DGX Spark with GB10 GPU
- CUDA 12.8 / Driver 580.95

### Build & Run:
```bash
cd server
docker build -f Dockerfile.arm64 -t nninteractive-slicer-server:arm64 .
docker run --gpus all -p 1527:1527 --ipc=host nninteractive-slicer-server:arm64
```

## Test plan
- [x] Built image on DGX Spark (ARM64)
- [x] Verified PyTorch CUDA availability
- [x] Server starts and accepts connections from 3D Slicer

🤖 Generated with [Claude Code](https://claude.ai/code)